### PR TITLE
add simple backend service for testing proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  serve:
+  proxy:
     build: .
     volumes:
       - ./src:/usr/local/tomcat/webapps
@@ -11,3 +11,10 @@ services:
       APP_NAME: 'helloservlet'
       APP_CLASS: 'mypkg'
     command: [ "run.sh" ]
+
+  service:
+    image: python
+    command: ["/usr/local/bin/python3", "-m", "http.server"]
+    expose:
+      - "8000"
+

--- a/src/helloservlet/WEB-INF/web.xml
+++ b/src/helloservlet/WEB-INF/web.xml
@@ -11,7 +11,7 @@
     <servlet-class>org.mitre.dsmiley.httpproxy.ProxyServlet</servlet-class>
     <init-param>
       <param-name>targetUri</param-name>
-      <param-value>http://google.com/</param-value>
+      <param-value>http://service:8000</param-value>
     </init-param>
     <init-param>
       <param-name>log</param-name>


### PR DESCRIPTION
adds a simple python http server to the the docker-compose file, configure this service as the targetUri for the HTTP-Proxy-Servlet

This makes more sense than testing against google as we can actually log the requests to the backend.

With this set up the proxy seems to work. After visting http://localhost:8080/helloservlet/sayhello I see the following:

![Screenshot from 2021-01-07 15-02-42](https://user-images.githubusercontent.com/9866884/103901439-70886d80-50f9-11eb-8043-ebc26b0110af.png)

Which is the output of pythons simple http server, being proxied by tomcat.

I think the redirects you where experiencing before were being served by google it self, and not the proxy server.